### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/Muhammadsmalik0420/83d6030f-b377-4fe1-9f35-c595ddb8f762/c948ee54-c53b-494a-b841-d26d7468c1f9/_apis/work/boardbadge/e25b4a1e-c6fb-4541-a402-5e39ac8d20ab)](https://dev.azure.com/Muhammadsmalik0420/83d6030f-b377-4fe1-9f35-c595ddb8f762/_boards/board/t/c948ee54-c53b-494a-b841-d26d7468c1f9/Microsoft.RequirementCategory)
 # Testing-01


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Muhammadsmalik0420/83d6030f-b377-4fe1-9f35-c595ddb8f762/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.